### PR TITLE
Fix memoized callback typing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
 
     <title>Interactive Child Rights Map</title>
     <meta
@@ -23,7 +19,6 @@
       content="child rights, kidsrights index, global child rights, child marriage, child labor, fgm, violent discipline, data map, country comparison, human rights dashboard"
     />
     <meta name="author" content="polakbear" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://ngau-sigma.vercel.app/" />
     <meta property="og:title" content="Interactive Child Rights Map" />

--- a/src/hooks/useMemoizedCallback.ts
+++ b/src/hooks/useMemoizedCallback.ts
@@ -15,6 +15,9 @@ export function useMemoizedCallback<T extends (...args: any[]) => any>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 
-  // @ts-expect-error foo bar
-  return useRef((...args) => ref.current(...args)).current;
+  const stableRef = useRef(
+    (...args: Parameters<T>): ReturnType<T> => ref.current(...args)
+  );
+
+  return stableRef.current as T;
 }


### PR DESCRIPTION
## Summary
- remove duplicate viewport meta tags in `index.html`
- improve type safety of `useMemoizedCallback`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685fac54b6ec832180420e3964d688d8